### PR TITLE
fix: 修正 claude-hud 插件 marketplace 标识

### DIFF
--- a/.claude/plugins.json
+++ b/.claude/plugins.json
@@ -50,7 +50,7 @@
     },
     {
       "id": "claude-hud",
-      "marketplace": "jarrodwatts",
+      "marketplace": "claude-hud",
       "name": "Claude HUD",
       "description": "终端状态栏实时显示 context 用量、工具状态、agent 进度"
     },


### PR DESCRIPTION
  - 将 claude-hud 的 marketplace 从 jarrodwatts 改为 claude-hud，与实际安装记录一致
  - 修复 sync-config.sh 每次运行都误判 claude-hud 未安装并重装失败的问题